### PR TITLE
Ensure that group permissions are set

### DIFF
--- a/templates/usr/local/bin/rsync_debian_mirror.j2
+++ b/templates/usr/local/bin/rsync_debian_mirror.j2
@@ -26,7 +26,7 @@ archexclude="{{ item.excludes | join(' ') | default("") }}"
 trace="project/trace/{{ repo_mirror_fqdn }}"
 
 # default rsync options
-rsync_opts="--bwlimit=${bwlimit} --timeout=600 --verbose --log-file="${log_file}" --no-motd --human-readable --recursive --hard-links --links --safe-links --times --delay-updates --temp-dir="${tmp_path}""
+rsync_opts="--bwlimit=${bwlimit} --timeout=600 --verbose --log-file="${log_file}" --perms --chmod=u=rwX,go=rX --no-motd --human-readable --recursive --hard-links --links --safe-links --times --delay-updates --temp-dir="${tmp_path}""
 stage1_rsync_opts="--exclude=Packages* --exclude=Sources* --exclude=Release* --exclude=InRelease --exclude=i18n/* --exclude=ls-lR*"
 stage2_rsync_opts="--max-delete=40000 --delay-updates --delete --delete-excluded"
 

--- a/templates/usr/local/bin/rsync_debian_mirror.j2
+++ b/templates/usr/local/bin/rsync_debian_mirror.j2
@@ -19,7 +19,6 @@ bwlimit="{{ item.bwlimit | default(repo_mirror_bwlimit) }}"
 rsync_timeout="{{ item.rsync_timeout | default(repo_mirror_rsync_timeout) }}"
 
 lock="/tmp/sync_{{ item.name }}_mirror.lck"
-lastupdate_tmp=$(mktemp)
 rsyncexitcode="-1"
 
 archexclude="{{ item.excludes | join(' ') | default("") }}"

--- a/templates/usr/local/bin/rsync_single_mirror.j2
+++ b/templates/usr/local/bin/rsync_single_mirror.j2
@@ -64,7 +64,7 @@ fi
 # start to rsync the mirror
 log-message 0 "Started {{ item.name }} mirror rsync job."
 rsync --verbose --log-file="${log}" --no-motd --human-readable --recursive \
-    --hard-links --links --safe-links --times \
+    --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
     --delete-after --delay-updates --temp-dir="${tmp_path}" \
     --bwlimit="${bwlimit}" --timeout="${rsync_timeout}" --contimeout=60 \
     "${repo_source}" \

--- a/templates/usr/local/bin/rsync_ubuntu_mirror.j2
+++ b/templates/usr/local/bin/rsync_ubuntu_mirror.j2
@@ -60,7 +60,7 @@ fi
 # start to rsync the mirror (stage 1)
 log-message 0 "Started stage 1 of {{ item.name }} mirror rsync job."
 rsync --verbose --log-file="${log_file}" --no-motd --human-readable --recursive \
-    --hard-links --links --safe-links --times --perms \
+    --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
     --delay-updates --temp-dir="${tmp_path}" \
     --bwlimit="${bwlimit}" --timeout=120 --contimeout=60 \
     --exclude "Packages*" --exclude "Sources*" \
@@ -78,7 +78,7 @@ fi
 # start to rsync the mirror (stage 2)
 log-message 0 "Started stage 2 of {{ item.name }} mirror rsync job."
 rsync --verbose --log-file="${log_file}" --no-motd --human-readable --recursive \
-    --hard-links --links --safe-links --times --perms \
+    --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
     --delete-after --temp-dir="${tmp_path}" \
     --bwlimit="${bwlimit}" --timeout=120 --contimeout=60 \
     "${repo_source}" \

--- a/templates/usr/local/bin/rsync_ubuntu_mirror.j2
+++ b/templates/usr/local/bin/rsync_ubuntu_mirror.j2
@@ -16,7 +16,6 @@ bwlimit="{{ item.bwlimit | default(repo_mirror_bwlimit) }}"
 rsync_timeout="{{ item.rsync_timeout | default(repo_mirror_rsync_timeout) }}"
 
 lock="/tmp/sync_{{ item.name }}_mirror.lck"
-lastupdate_tmp=$(mktemp)
 rsyncexitcode="-1"
 
 
@@ -51,11 +50,6 @@ function log-message() {
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"
 flock -n 9 || log-message 1 "{{ item.name }} mirror rsync job is already running!" 1
-
-# exit if there weren't any changes
-if diff -b <(curl -s "${lastupdate_url}") "${base_path}/project/trace/{{ repo_mirror_fqdn }}" >/dev/null; then
-    log-message 1 "Mirror is already up to date!" 0
-fi
 
 # start to rsync the mirror (stage 1)
 log-message 0 "Started stage 1 of {{ item.name }} mirror rsync job."

--- a/templates/usr/local/bin/wget_mirror.j2
+++ b/templates/usr/local/bin/wget_mirror.j2
@@ -16,7 +16,6 @@ bwlimit="{{ item.bwlimit | default(repo_mirror_bwlimit) }}"
 rsync_timeout="{{ item.rsync_timeout | default(repo_mirror_rsync_timeout) }}"
 
 lock="/tmp/sync_{{ item.name }}_mirror.lck"
-lastupdate_tmp=$(mktemp)
 exitcode="-1"
 
 remotegpgkey="{{ item.remotegpgkey }}"


### PR DESCRIPTION
By adding --chmod=u=rwX,go=rX to the rsync command we can ensure that
all files and directories have group read permissions.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

By adding --chmod=u=rwX,go=rX to the rsync command we can ensure that
all files and directories have group read permissions.

Additionally by removing the copy/pasted instructions from rsync_ubuntu_mirror.j2 it also fixes #7 

##### ISSUE TYPE
 - Bugfix Pull Request
