### PR TITLE
Prevent sync scripts from being unknowingly run as root

### DIFF
--- a/templates/usr/local/bin/rsync_debian_mirror.j2
+++ b/templates/usr/local/bin/rsync_debian_mirror.j2
@@ -12,6 +12,7 @@ tmp_path={{ repo_mirror_tmp_path | quote }}
 base_path={{ repo_mirror_base_path | quote }}/$repo_name
 log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
 status_file=$base_path.json
+owner={{ repo_mirror_user | quote }}
 
 repo_source={{ item.source_repo | quote }}
 
@@ -80,6 +81,17 @@ function log-message() {
         exit ${exitcode}
     fi
 }
+
+# Running as the incorrect user (probably root) could potentially create files
+# with the wrong ownership, leading to issues for later syncs:
+if ! username=$(id -un); then
+    echo 'Could not obtain user name.'
+    exit 1
+fi
+if [ "$username" != "$owner" ]; then
+    echo "Running as $username, but must run as $owner, otherwise this will break future syncs!"
+    exit 1
+fi
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"

--- a/templates/usr/local/bin/rsync_debian_mirror.j2
+++ b/templates/usr/local/bin/rsync_debian_mirror.j2
@@ -7,22 +7,23 @@
 # uncomment to enable bash debugging
 #set -x
 
-tmp_path="{{ repo_mirror_tmp_path }}"
-base_path="{{ repo_mirror_base_path }}/{{ item.name }}"
-log_file="{{ repo_mirror_log_path }}/{{ item.name }}/repo_{{ item.name }}.log"
-status_file="{{ repo_mirror_base_path }}/{{ item.name }}.json"
+repo_name={{ item.name | quote }}
+tmp_path={{ repo_mirror_tmp_path | quote }}
+base_path={{ repo_mirror_base_path | quote }}/$repo_name
+log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
+status_file=$base_path.json
 
-repo_source="{{ item.source_repo }}"
+repo_source={{ item.source_repo | quote }}
 
-datetime_format="{{ repo_mirror_datetime_format }}"
-bwlimit="{{ item.bwlimit | default(repo_mirror_bwlimit) }}"
-rsync_timeout="{{ item.rsync_timeout | default(repo_mirror_rsync_timeout) }}"
+datetime_format={{ repo_mirror_datetime_format | quote }}
+bwlimit={{ item.bwlimit | default(repo_mirror_bwlimit) | quote }}
+rsync_timeout={{ item.rsync_timeout | default(repo_mirror_rsync_timeout) | quote }}
 
-lock="/tmp/sync_{{ item.name }}_mirror.lck"
-rsyncexitcode="-1"
+lock=/tmp/sync_${repo_name}_mirror.lck
+rsyncexitcode=-1
 
-archexclude="{{ item.excludes | join(' ') | default("") }}"
-trace="project/trace/{{ repo_mirror_fqdn }}"
+archexclude={{ item.excludes | join(" ") | default("") | quote }}
+trace=project/trace/{{ repo_mirror_fqdn | quote }}
 
 # default rsync options
 rsync_opts="--bwlimit=${bwlimit} --timeout=600 --verbose --log-file="${log_file}" --perms --chmod=u=rwX,go=rX --no-motd --human-readable --recursive --hard-links --links --safe-links --times --delay-updates --temp-dir="${tmp_path}""
@@ -82,7 +83,7 @@ function log-message() {
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"
-flock -n 9 || log-message 1 "{{ item.name }} mirror rsync job is already running!" 1
+flock -n 9 || log-message 1 "$repo_name mirror rsync job is already running!" 1
 
 # The temp directory used by rsync --delay-updates is not
 # world-readable remotely. Always exclude it to avoid errors.
@@ -101,7 +102,7 @@ for ARCH in ${archexclude}; do
     fi
 done
 
-log-message 0 "Running stage 1 of {{ item.name }} rsync job"
+log-message 0 "Running stage 1 of $repo_name rsync job"
 rsync ${rsync_opts} \
     ${stage1_rsync_opts} \
     ${exclude} ${sourceexclude}\
@@ -115,7 +116,7 @@ else
     log-message 1 "rsync had an error while running the first stage." ${rsyncexitcode}
 fi
 
-log-message 0 "Running stage 2 of {{ item.name }} rsync job"
+log-message 0 "Running stage 2 of $repo_name rsync job"
 rsync ${rsync_opts} \
     ${stage2_rsync_opts} \
     ${exclude} ${sourceexclude}\
@@ -125,7 +126,7 @@ rsyncexitcode="$?"
 
 if [ "${rsyncexitcode}" = "0" ]; then
     log-message 0 "Second stage of rsync done successfully."
-    log-message 1 "Finished {{ item.name }} mirror rsync job." ${rsyncexitcode} # -> exit 0
+    log-message 1 "Finished $repo_name mirror rsync job." ${rsyncexitcode} # -> exit 0
 else
     log-message 1 "rsync had an error while running the second stage." ${rsyncexitcode}
 fi

--- a/templates/usr/local/bin/rsync_debian_mirror.j2
+++ b/templates/usr/local/bin/rsync_debian_mirror.j2
@@ -22,7 +22,7 @@ rsync_timeout={{ item.rsync_timeout | default(repo_mirror_rsync_timeout) | quote
 lock=/tmp/sync_${repo_name}_mirror.lck
 rsyncexitcode=-1
 
-archexclude={{ item.excludes | join(" ") | default("") | quote }}
+archexclude={{ item.excludes | default([]) | join(" ") | quote }}
 trace=project/trace/{{ repo_mirror_fqdn | quote }}
 
 # default rsync options

--- a/templates/usr/local/bin/rsync_single_mirror.j2
+++ b/templates/usr/local/bin/rsync_single_mirror.j2
@@ -9,6 +9,7 @@ tmp_path={{ repo_mirror_tmp_path | quote }}
 base_path={{ repo_mirror_base_path | quote }}/$repo_name
 log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
 status_file=$base_path.json
+owner={{ repo_mirror_user | quote }}
 
 repo_source={{ item.source_repo | quote }}
 
@@ -51,6 +52,17 @@ function log-message() {
         exit ${exitcode}
     fi
 }
+
+# Running as the incorrect user (probably root) could potentially create files
+# with the wrong ownership, leading to issues for later syncs:
+if ! username=$(id -un); then
+    echo 'Could not obtain user name.'
+    exit 1
+fi
+if [ "$username" != "$owner" ]; then
+    echo "Running as $username, but must run as $owner, otherwise this will break future syncs!"
+    exit 1
+fi
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"

--- a/templates/usr/local/bin/rsync_single_mirror.j2
+++ b/templates/usr/local/bin/rsync_single_mirror.j2
@@ -4,20 +4,21 @@
 # usage:    This script is used to mirror the {{ item.name }} package repository.
 #
 
-tmp_path="{{ repo_mirror_tmp_path }}"
-base_path="{{ repo_mirror_base_path }}/{{ item.name }}"
-log_file="{{ repo_mirror_log_path }}/{{ item.name }}/repo_{{ item.name }}.log"
-status_file="{{ repo_mirror_base_path }}/{{ item.name }}.json"
+repo_name={{ item.name | quote }}
+tmp_path={{ repo_mirror_tmp_path | quote }}
+base_path={{ repo_mirror_base_path | quote }}/$repo_name
+log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
+status_file=$base_path.json
 
-repo_source="{{ item.source_repo }}"
+repo_source={{ item.source_repo | quote }}
 
-datetime_format="{{ repo_mirror_datetime_format }}"
-bwlimit="{{ item.bwlimit | default(repo_mirror_bwlimit) }}"
-rsync_timeout="{{ item.rsync_timeout | default(repo_mirror_rsync_timeout) }}"
+datetime_format={{ repo_mirror_datetime_format | quote }}
+bwlimit={{ item.bwlimit | default(repo_mirror_bwlimit) | quote }}
+rsync_timeout={{ item.rsync_timeout | default(repo_mirror_rsync_timeout) | quote }}
 
-lock="/tmp/sync_{{ item.name }}_mirror.lck"
+lock=/tmp/sync_${repo_name}_mirror.lck
 lastupdate_tmp=$(mktemp)
-rsyncexitcode="-1"
+rsyncexitcode=-1
 
 function writestatistics() {
     local syncsize="$(du -h "${base_path}" | tail -1 | cut -f1)"
@@ -53,7 +54,7 @@ function log-message() {
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"
-flock -n 9 || log-message 1 "{{ item.name }} mirror rsync job is already running!" 1
+flock -n 9 || log-message 1 "$repo_name mirror rsync job is already running!" 1
 
 # exit if there weren't any changes
 rsync "${repo_source}/lastupdate" "${lastupdate_tmp}"
@@ -62,7 +63,7 @@ if diff -b "${lastupdate_tmp}" "${base_path}/lastupdate" >/dev/null; then
 fi
 
 # start to rsync the mirror
-log-message 0 "Started {{ item.name }} mirror rsync job."
+log-message 0 "Started $repo_name mirror rsync job."
 rsync --verbose --log-file="${log}" --no-motd --human-readable --recursive \
     --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
     --delete-after --delay-updates --temp-dir="${tmp_path}" \
@@ -72,7 +73,7 @@ rsync --verbose --log-file="${log}" --no-motd --human-readable --recursive \
 rsyncexitcode="$?"
 
 if [ "${rsyncexitcode}" = "0" ]; then
-    log-message 1 "Finished {{ item.name }} mirror rsync job." ${rsyncexitcode} # = 0
+    log-message 1 "Finished $repo_name mirror rsync job." ${rsyncexitcode} # = 0
 else
     log-message 1 "Rsync had an error: ${rsyncexitcode}" ${rsyncexitcode} # >= 1
 fi

--- a/templates/usr/local/bin/rsync_ubuntu_mirror.j2
+++ b/templates/usr/local/bin/rsync_ubuntu_mirror.j2
@@ -9,6 +9,7 @@ tmp_path={{ repo_mirror_tmp_path | quote }}
 base_path={{ repo_mirror_base_path | quote }}/$repo_name
 log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
 status_file=$base_path.json
+owner={{ repo_mirror_user | quote }}
 
 repo_source={{ item.source_repo | quote }}
 
@@ -47,6 +48,17 @@ function log-message() {
         exit ${exitcode}
     fi
 }
+
+# Running as the incorrect user (probably root) could potentially create files
+# with the wrong ownership, leading to issues for later syncs:
+if ! username=$(id -un); then
+    echo 'Could not obtain user name.'
+    exit 1
+fi
+if [ "$username" != "$owner" ]; then
+    echo "Running as $username, but must run as $owner, otherwise this will break future syncs!"
+    exit 1
+fi
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"

--- a/templates/usr/local/bin/rsync_ubuntu_mirror.j2
+++ b/templates/usr/local/bin/rsync_ubuntu_mirror.j2
@@ -4,19 +4,20 @@
 # usage:    This script is used to mirror the {{ item.name }} package repository.
 #
 
-tmp_path="{{ repo_mirror_tmp_path }}"
-base_path="{{ repo_mirror_base_path }}/{{ item.name }}"
-log_file="{{ repo_mirror_log_path }}/{{ item.name }}/repo_{{ item.name }}.log"
-status_file="{{ repo_mirror_base_path }}/{{ item.name }}.json"
+repo_name={{ item.name | quote }}
+tmp_path={{ repo_mirror_tmp_path | quote }}
+base_path={{ repo_mirror_base_path | quote }}/$repo_name
+log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
+status_file=$base_path.json
 
-repo_source="{{ item.source_repo }}"
+repo_source={{ item.source_repo | quote }}
 
-datetime_format="{{ repo_mirror_datetime_format }}"
-bwlimit="{{ item.bwlimit | default(repo_mirror_bwlimit) }}"
-rsync_timeout="{{ item.rsync_timeout | default(repo_mirror_rsync_timeout) }}"
+datetime_format={{ repo_mirror_datetime_format | quote }}
+bwlimit={{ item.bwlimit | default(repo_mirror_bwlimit) | quote }}
+rsync_timeout={{ item.rsync_timeout | default(repo_mirror_rsync_timeout) | quote }}
 
-lock="/tmp/sync_{{ item.name }}_mirror.lck"
-rsyncexitcode="-1"
+lock=/tmp/sync_${repo_name}_mirror.lck
+rsyncexitcode=-1
 
 
 function writestatistics() {
@@ -49,10 +50,10 @@ function log-message() {
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"
-flock -n 9 || log-message 1 "{{ item.name }} mirror rsync job is already running!" 1
+flock -n 9 || log-message 1 "$repo_name mirror rsync job is already running!" 1
 
 # start to rsync the mirror (stage 1)
-log-message 0 "Started stage 1 of {{ item.name }} mirror rsync job."
+log-message 0 "Started stage 1 of $repo_name mirror rsync job."
 rsync --verbose --log-file="${log_file}" --no-motd --human-readable --recursive \
     --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
     --delay-updates --temp-dir="${tmp_path}" \
@@ -70,7 +71,7 @@ else
 fi
 
 # start to rsync the mirror (stage 2)
-log-message 0 "Started stage 2 of {{ item.name }} mirror rsync job."
+log-message 0 "Started stage 2 of $repo_name mirror rsync job."
 rsync --verbose --log-file="${log_file}" --no-motd --human-readable --recursive \
     --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
     --delete-after --temp-dir="${tmp_path}" \
@@ -82,7 +83,7 @@ rsyncexitcode="$?"
 if [ "${rsyncexitcode}" = "0" ]; then
     log-message 0 "Second stage of rsync done successfully."
     date -u > ${base_path}/project/trace/$(hostname -f)
-    log-message 1 "Finished {{ item.name }} mirror rsync job." ${rsyncexitcode} # -> exit 0
+    log-message 1 "Finished $repo_name mirror rsync job." ${rsyncexitcode} # -> exit 0
 else
     log-message 1 "First stage of rsync done successfully." ${rsyncexitcode}
 fi

--- a/templates/usr/local/bin/wget_mirror.j2
+++ b/templates/usr/local/bin/wget_mirror.j2
@@ -4,21 +4,22 @@
 # usage:    This script is used to mirror the {{ item.name }} package repository.
 #
 
-tmp_path="{{ repo_mirror_tmp_path }}"
-base_path="{{ repo_mirror_base_path }}/{{ item.name }}"
-log_file="{{ repo_mirror_log_path }}/{{ item.name }}/repo_{{ item.name }}.log"
-status_file="{{ repo_mirror_base_path }}/{{ item.name }}.json"
+repo_name={{ item.name | quote }}
+tmp_path={{ repo_mirror_tmp_path | quote }}
+base_path={{ repo_mirror_base_path | quote }}/$repo_name
+log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
+status_file=$base_path.json
 
-repo_source="{{ item.source_repo }}"
+repo_source={{ item.source_repo | quote }}
 
-datetime_format="{{ repo_mirror_datetime_format }}"
-bwlimit="{{ item.bwlimit | default(repo_mirror_bwlimit) }}"
-rsync_timeout="{{ item.rsync_timeout | default(repo_mirror_rsync_timeout) }}"
+datetime_format={{ repo_mirror_datetime_format | quote }}
+bwlimit={{ item.bwlimit | default(repo_mirror_bwlimit) | quote }}
+rsync_timeout={{ item.rsync_timeout | default(repo_mirror_rsync_timeout) | quote }}
 
-lock="/tmp/sync_{{ item.name }}_mirror.lck"
-exitcode="-1"
+lock=/tmp/sync_${repo_name}_mirror.lck
+exitcode=-1
 
-remotegpgkey="{{ item.remotegpgkey }}"
+remotegpgkey={{ item.remotegpgkey | quote }}
 
 
 function writestatistics() {
@@ -51,9 +52,9 @@ function log-message() {
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"
-flock -n 9 || log-message 1 "{{ item.name }} mirror rsync job is already running!" 1
+flock -n 9 || log-message 1 "$repo_name mirror rsync job is already running!" 1
 
-log-message 0 "Started {{ item.name }} mirror sync job."
+log-message 0 "Started $repo_name mirror sync job."
 
 # Sync GPG Key
 wget -c ${remotegpgkey} --directory-prefix=${base_path}
@@ -69,7 +70,7 @@ exitcode="$?"
 find ${base_path} -name '*html' -exec rm {} \;
 
 if [ "${exitcode}" = "0" ]; then
-    log-message 1 "Finished {{ item.name }} mirror sync job." ${exitcode} # = 0
+    log-message 1 "Finished $repo_name mirror sync job." ${exitcode} # = 0
 else
     log-message 1 "Sync job had an error: ${exitcode}" ${exitcode} # >= 1
 fi

--- a/templates/usr/local/bin/wget_mirror.j2
+++ b/templates/usr/local/bin/wget_mirror.j2
@@ -9,6 +9,7 @@ tmp_path={{ repo_mirror_tmp_path | quote }}
 base_path={{ repo_mirror_base_path | quote }}/$repo_name
 log_file={{ repo_mirror_log_path | quote }}/$repo_name/repo_$repo_name.log
 status_file=$base_path.json
+owner={{ repo_mirror_user | quote }}
 
 repo_source={{ item.source_repo | quote }}
 
@@ -49,6 +50,17 @@ function log-message() {
         exit ${exitcode}
     fi
 }
+
+# Running as the incorrect user (probably root) could potentially create files
+# with the wrong ownership, leading to issues for later syncs:
+if ! username=$(id -un); then
+    echo 'Could not obtain user name.'
+    exit 1
+fi
+if [ "$username" != "$owner" ]; then
+    echo "Running as $username, but must run as $owner, otherwise this will break future syncs!"
+    exit 1
+fi
 
 # create lock or exit if already locked in order to prevent multiple syncs
 exec 9>"${lock}"


### PR DESCRIPTION
##### SUMMARY

The repo mirror files are usually owned by a given service user (`{{ repo_mirror_user }}`, by default that's `mirror`). If they someone become owned by a different user (e.g. because some sysadmin unknowingly runs a sync script as root as part of some mirror sync issue troubleshooting), this will cause issues at later runs, because the service user may no longer be able to remove the files owned by the other user.

These changes add a check to the sync scripts to ensure that they are invoked as the correct user (and otherwise error out with an appropriate error message).

##### ISSUE TYPE

 - Feature Pull Request

##### ANSIBLE VERSION

```
ansible 2.10.8
  config file = None
  configured module search path = ['/home/martinwe/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.9.2 (default, Feb 28 2021, 17:03:44) [GCC 10.2.1 20210110]
```

##### ADDITIONAL INFORMATION

There are two commits here: The second one introduces the change described above, while the first one fixes some of the quoting issues with Jinja2/shell.